### PR TITLE
Include custom `EventTarget` and `Event` classes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,6 +134,8 @@ const config = tsEslint.config(
 				'type-annotation',
 			],
 			'@typescript-eslint/dot-notation': 0,
+			'@typescript-eslint/no-empty-function': 0,
+			'@typescript-eslint/no-inferrable-types': 0,
 			'@typescript-eslint/no-unused-vars': [
 				2,
 				{

--- a/src/FakeEvent.ts
+++ b/src/FakeEvent.ts
@@ -1,0 +1,68 @@
+export class FakeEvent {
+	/**
+	 * Constants.
+	 */
+	readonly NONE = 0;
+	readonly CAPTURING_PHASE = 1;
+	readonly AT_TARGET = 2;
+	readonly BUBBLING_PHASE = 3;
+	/**
+	 * Members.
+	 */
+	readonly type: string;
+	readonly bubbles: boolean;
+	readonly cancelable: boolean;
+	defaultPrevented: boolean = false;
+	readonly composed: boolean = false;
+	readonly currentTarget: any = undefined;
+	// Not implemented.
+	readonly eventPhase: number = this.NONE;
+	readonly isTrusted: boolean = true;
+	readonly target: any = undefined;
+	readonly timeStamp: number = 0;
+	// Deprecated.
+	readonly cancelBubble: boolean = false;
+	readonly returnValue: boolean = true;
+	readonly srcElement: any = undefined;
+
+	constructor(
+		type: string,
+		options: { bubbles?: boolean; cancelable?: boolean } = {}
+	) {
+		this.type = type;
+		this.bubbles = options.bubbles ?? false;
+		this.cancelable = options.cancelable ?? false;
+	}
+
+	preventDefault(): void {
+		if (this.cancelable) {
+			this.defaultPrevented = true;
+		}
+	}
+
+	/**
+	 * Not implemented.
+	 */
+	stopPropagation(): void {}
+
+	/**
+	 * Not implemented.
+	 */
+	stopImmediatePropagation(): void {}
+
+	/**
+	 * Not implemented.
+	 */
+	composedPath(): any[] {
+		return [];
+	}
+
+	/**
+	 * Not implemented.
+	 * @deprecated
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	initEvent(type: string, bubbles: boolean, cancelable: true): void {
+		// Not implemented.
+	}
+}

--- a/src/FakeEventTarget.ts
+++ b/src/FakeEventTarget.ts
@@ -1,0 +1,72 @@
+import { FakeEvent } from './FakeEvent';
+
+type FakeEventListener = (event: FakeEvent) => void;
+
+export interface FakeListenerOptions {
+	once?: boolean;
+}
+
+interface FakeListenerEntry {
+	callback: FakeEventListener;
+	once: boolean;
+}
+
+export class FakeEventTarget implements EventTarget {
+	private listeners: Record<string, FakeListenerEntry[]> = {};
+
+	addEventListener(
+		type: string,
+		callback: FakeEventListener,
+		options: FakeListenerOptions = {}
+	): void {
+		if (!callback) {
+			return;
+		}
+
+		this.listeners[type] ??= [];
+
+		this.listeners[type].push({
+			callback,
+			once: options.once === true,
+		});
+	}
+
+	removeEventListener(type: string, callback: FakeEventListener): void {
+		if (!this.listeners[type]) {
+			return;
+		}
+
+		this.listeners[type] = this.listeners[type].filter(
+			listener => listener.callback !== callback
+		);
+	}
+
+	dispatchEvent(event: Event): boolean {
+		if (!event || typeof event.type !== 'string') {
+			throw new Error('invalid event object');
+		}
+
+		const entries = this.listeners[event.type];
+
+		if (!entries) {
+			return true;
+		}
+
+		for (const listener of [...entries]) {
+			try {
+				listener.callback.call(this, event);
+			} catch (error) {
+				// Avoid that the error breaks the iteration.
+				setTimeout(() => {
+					throw error;
+				}, 0);
+			}
+
+			if (listener.once) {
+				this.removeEventListener(event.type, listener.callback);
+			}
+		}
+
+		return !event.defaultPrevented;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { FakeEventTarget, FakeListenerOptions } from './FakeEventTarget';
 import { clone } from './utils';
 
 export type AppData = {
@@ -29,7 +30,7 @@ export interface FakeMediaStreamTrackEventMap extends MediaStreamTrackEventMap {
 export class FakeMediaStreamTrack<
 		FakeMediaStreamTrackAppData extends AppData = AppData,
 	>
-	extends EventTarget
+	extends FakeEventTarget
 	implements MediaStreamTrack
 {
 	readonly #id: string;
@@ -239,7 +240,7 @@ export class FakeMediaStreamTrack<
 			this: FakeMediaStreamTrack,
 			ev: FakeMediaStreamTrackEventMap[K]
 		) => any,
-		options?: boolean | AddEventListenerOptions
+		options?: FakeListenerOptions
 	): void {
 		super.addEventListener(type, listener, options);
 	}
@@ -249,10 +250,9 @@ export class FakeMediaStreamTrack<
 		listener: (
 			this: FakeMediaStreamTrack,
 			ev: FakeMediaStreamTrackEventMap[K]
-		) => any,
-		options?: boolean | EventListenerOptions
+		) => any
 	): void {
-		super.removeEventListener(type, listener, options);
+		super.removeEventListener(type, listener);
 	}
 
 	/**


### PR DESCRIPTION
## Motivation

- `EventTarget` and `Event` classes re not implemented in Hermes JS implementation (used by React-Native).
- Fixes #6