### PR TITLE
Nullish Coalescing Assignment operator replacement

### DIFF
--- a/src/fakeEvents/FakeEventTarget.ts
+++ b/src/fakeEvents/FakeEventTarget.ts
@@ -23,7 +23,7 @@ export class FakeEventTarget implements EventTarget {
 			return;
 		}
 
-		this.listeners[type] ??= [];
+		this.listeners[type] = this.listeners[type] ?? [];
 
 		this.listeners[type].push({
 			callback:


### PR DESCRIPTION
Operator _Nullish Coalescing Assignment_ (??=) is not supported in older browsers below Chrome 87 and causes a syntax error `Uncaught SyntaxError: Unexpected token '='`.

PR replaces operator call with two separate operators:
`variable ??= expression` => `variable = variable ?? expression`